### PR TITLE
mob spawn tweaks to time of day etc

### DIFF
--- a/servers/minecraft/plugins/Mobzy/spawns.yml
+++ b/servers/minecraft/plugins/Mobzy/spawns.yml
@@ -386,9 +386,9 @@ regions:
           - GRASS_BLOCK
           
       - mob: Kagi Tachikiri
-        max-amount: 5
+        max-amount: 4
         radius: 10
-        max-local-group: 10
+        max-local-group: 6
         local-group-radius: 300
         block-whitelist:
           - SAND

--- a/servers/minecraft/plugins/Mobzy/spawns.yml
+++ b/servers/minecraft/plugins/Mobzy/spawns.yml
@@ -266,7 +266,7 @@ regions:
         max-local-group: 1
         local-group-radius: 300 
         min-Time: 6000
-        max-Time: 13000
+        max-Time: 9000
         block-whitelist:
           - WATER
 

--- a/servers/minecraft/plugins/Mobzy/spawns.yml
+++ b/servers/minecraft/plugins/Mobzy/spawns.yml
@@ -172,7 +172,13 @@ regions:
         local-group-radius: 200
         max-y: 100
         priority: 0.3
-        
+
+      - reuse: Template:Neritantan
+        radius: 20
+        max-local-group: 6
+        local-group-radius: 150
+        max-y: 45
+
       - reuse: Template:Dosetori
         max-y: 100
 
@@ -196,12 +202,7 @@ regions:
 
       - reuse: Template:Dosetori
 
-      - mob: Template:Neritantan
-        radius: 100
-        max-local-group: 6
-        local-group-radius: 100
-        max-light: 7
-        max-y: 45
+      - reuse: Template:Neritantan
 
       - mob: Madokajack
         min-y: 20

--- a/servers/minecraft/plugins/Mobzy/spawns.yml
+++ b/servers/minecraft/plugins/Mobzy/spawns.yml
@@ -263,11 +263,10 @@ regions:
   - name: The Goblet of Giants
     spawns:
       - mob: Tamaugachi
-        max-light: 7
         max-local-group: 1
         local-group-radius: 300 
-        min-Time: 17843
-        max-Time: 18000
+        min-Time: 6000
+        max-Time: 13000
         block-whitelist:
           - WATER
 

--- a/servers/minecraft/plugins/Mobzy/spawns.yml
+++ b/servers/minecraft/plugins/Mobzy/spawns.yml
@@ -159,7 +159,8 @@ regions:
         radius: 10
         max-local-group: 3
         local-group-radius: 100
-        max-light: 7
+        min-Time: 13000
+        max-Time: 23000
         block-whitelist:
           - GRASS_BLOCK
 
@@ -170,12 +171,6 @@ regions:
         local-group-radius: 200
         max-y: 100
         priority: 0.3
-
-      - reuse: Template:Neritantan
-        radius: 100
-        max-local-group: 6
-        local-group-radius: 100
-        max-y: 45
 
       - reuse: Template:Dosetori
         max-y: 100
@@ -200,7 +195,12 @@ regions:
 
       - reuse: Template:Dosetori
 
-      - reuse: Template:Neritantan
+      - mob: Template:Neritantan
+        radius: 100
+        max-local-group: 6
+        local-group-radius: 100
+        max-light: 7
+        max-y: 45
 
       - mob: Madokajack
         min-y: 20
@@ -265,8 +265,8 @@ regions:
       - mob: Tamaugachi
         max-local-group: 1
         local-group-radius: 300 
-        min-Time: 6000
-        max-Time: 9000
+        min-Time: 18000
+        max-Time: 23000
         block-whitelist:
           - WATER
 

--- a/servers/minecraft/plugins/Mobzy/spawns.yml
+++ b/servers/minecraft/plugins/Mobzy/spawns.yml
@@ -265,7 +265,9 @@ regions:
       - mob: Tamaugachi
         max-light: 7
         max-local-group: 1
-        local-group-radius: 300
+        local-group-radius: 300 
+        min-Time: 17843
+        max-Time: 18000
         block-whitelist:
           - WATER
 


### PR DESCRIPTION
honestly wanted to buff kuons but it wouldnt make much sense since adding more would have the same problem as kagis. 

nerf kagi spawn because currently, it serves as a much bigger threat than one of the biggest threats in canon. (personally dont like ocs being harder than canon but subjective ig). 