### PR TITLE
hp tweaks for makihige, titanjaws, abyssal snail

### DIFF
--- a/servers/minecraft/plugins/Geary/mineinabyss/mobs/passive/abyssal_snail.yml
+++ b/servers/minecraft/plugins/Geary/mineinabyss/mobs/passive/abyssal_snail.yml
@@ -4,7 +4,7 @@
 - !<mobzy:model>
   id: 98
 - !<mobzy:attributes>
-  maxHealth: 30
+  maxHealth: 40
   movementSpeed: 0.1000
   knockbackResistance: 0.1500
   followRange: 20

--- a/servers/minecraft/plugins/Geary/mineinabyss/mobs/passive/makihige.yml
+++ b/servers/minecraft/plugins/Geary/mineinabyss/mobs/passive/makihige.yml
@@ -4,7 +4,7 @@
 - !<mobzy:model>
   id: 56
 - !<mobzy:attributes>
-  maxHealth: 10
+  maxHealth: 60
   movementSpeed: 0.2000
   knockbackResistance: 0.2000
   width: 2

--- a/servers/minecraft/plugins/Geary/mineinabyss/mobs/passive/titanjaw.yml
+++ b/servers/minecraft/plugins/Geary/mineinabyss/mobs/passive/titanjaw.yml
@@ -4,7 +4,7 @@
 - !<mobzy:model>
   id: 83
 - !<mobzy:attributes>
-  maxHealth: 60
+  maxHealth: 20
   movementSpeed: 0.1500
   knockbackResistance: 0.3000
   width: 2


### PR DESCRIPTION
abyssal snails and makihige should be harder to kill due to their shells and titanjaws taking 5 crits from a diamond axe doesn't make sense at all

typo for abyssal snail that's supposed to be 30 > 40 oops

_yes i know i could've done this commit in github desktop but m too lazy :siggy:_