### PR TITLE
Ladders and fall distance update

### DIFF
--- a/servers/minecraft/plugins/StaminaClimb/config.yml
+++ b/servers/minecraft/plugins/StaminaClimb/config.yml
@@ -3,13 +3,13 @@ staminaRegen: 0.01
 staminaRegenInAir: 0.003
 staminaRemovePerTick: 0.005
 staminaRemoveWhileMoving: 0.005
-staminaRemoveWhileOnLadder: 0.004
+staminaRemoveWhileOnLadder: 0.00125
 barRed: 0.02
 barBlink1: 0.3
 barBlink2: 0.15
 barBlinkSpeed1: 200
 barBlinkSpeed2: 50
-maxFallDist: 5
+maxFallDist: 6 
 jumpCooldown: 300
 walljumpCooldown: 300
 roofClimbDifficulty: 7.0


### PR DESCRIPTION
So 2 things, fall distance increse to give more time if you fall so you can stick to a near wall (high ping players), ladders time increace to make it 48 instead of 30, several players suggested this, can be a good change if not just revert it :)