### PR TITLE
Update orbpiercer.yml

### DIFF
--- a/servers/mobs/sync/plugins/MythicMobs/Skills/mineinabyss/orbpiercer.yml
+++ b/servers/mobs/sync/plugins/MythicMobs/Skills/mineinabyss/orbpiercer.yml
@@ -37,7 +37,7 @@ orbyhit:
   Conditions:
   Cooldown:
   Skills:
-    - damage{amount=5}
+    - damage{amount=8}
     - potion{type=POISON;duration=150;level=5}
     - potion{type=WITHER;duration=150;level=5}
     - skill{s=Bleeding} @target
@@ -46,7 +46,7 @@ orbyend:
   Conditions:
   Cooldown:
   Skills:
-    - damage{amount=5}
+    - damage{amount=8}
     - potion{type=POISON;duration=100;level=5}
     - potion{type=WITHER;duration=30;level=1}
     - skill{s=Bleeding} @target
@@ -200,6 +200,7 @@ orby_impale:
   Conditions:
     - offgcd true
     - targetinlineofsight
+    - heightabove{h=5} false
   #- stance{s=spikeless;str=true} false
   Skills:
     - gcd{ticks=50}
@@ -208,7 +209,7 @@ orby_impale:
     - state{s=dash_charge;li=0;lo=0} @self
     - look{headOnly=false;immediately=false;repeat=50;repeatinterval=1} @target
     - delay 15
-    - leap{velocity=600} @Target
+    - leap{velocity=500} @Target
     - state{s=dash_charge;r=true} @self
     - state{s=dash_land_and_impale;li=0;lo=0} @self
     - delay 8


### PR DESCRIPTION
updated projectile damage
changed leap skill to only work if target isn't above 5 blocks