### PR TITLE
Buffs and nerfs

### DIFF
--- a/servers/mobs/sync/plugins/MythicMobs/Mobs/mineinabyss/flying/kagi_tachikiri.yml
+++ b/servers/mobs/sync/plugins/MythicMobs/Mobs/mineinabyss/flying/kagi_tachikiri.yml
@@ -4,7 +4,7 @@ kagi_tachikiri:
   Damage: 6
   AIGoalSelectors:
     - clear
-    - meleeattack{speed=1.5;range=1.5}
+    - meleeattack
     - float
     - randomFly
     - randomlookaround
@@ -28,7 +28,7 @@ kagi_tachikiri:
   Skills:
     - bodyclamp{m=kagi_tachikiri;c=15} @self ~onSpawn
     - bodyclamp{m=kagi_tachikiri;c=15} @self ~onLoad
-    - setspeed{type=flying;speed=1.5} @self ~onSpawn
+    - setspeed{type=flying;speed=1.4} @self ~onSpawn
     - state{mid=kagi_tachikiri;s=attack} @self ~onAttack
     
-    - skill{s=kagi_venom} @target ~onTimer:10
+    - skill{s=kagi_venom} @target ~onTimer:80

--- a/servers/mobs/sync/plugins/MythicMobs/Mobs/mineinabyss/flying/madokajack.yml
+++ b/servers/mobs/sync/plugins/MythicMobs/Mobs/mineinabyss/flying/madokajack.yml
@@ -4,7 +4,7 @@ madokajack:
   Damage: 5
   AIGoalSelectors:
     - clear
-    - meleeattack{speed=1.5;range=1.5}
+    - meleeattack
     - float
     - randomFly
     - randomlookaround

--- a/servers/mobs/sync/plugins/MythicMobs/Mobs/mineinabyss/orbpiercer.yml
+++ b/servers/mobs/sync/plugins/MythicMobs/Mobs/mineinabyss/orbpiercer.yml
@@ -21,7 +21,7 @@ OrbPiercer:
     Silent: true
     FollowRange: 48
     MovementSpeed: 0.3
-    MaxCombatDistance: 25
+    MaxCombatDistance: 40
   Equipment:
     - DIAMOND_BOOTS{enchants=DEPTH_STRIDER:3} FEET
   Drops:

--- a/servers/mobs/sync/plugins/MythicMobs/Mobs/mineinabyss/orbpiercer.yml
+++ b/servers/mobs/sync/plugins/MythicMobs/Mobs/mineinabyss/orbpiercer.yml
@@ -1,5 +1,5 @@
 OrbPiercer:
-  Type: DROWNED
+  Type: ZOMBIE
   Display: 'OrbPiercer'
   Health: 125
   Damage: 7
@@ -21,7 +21,7 @@ OrbPiercer:
     Silent: true
     FollowRange: 48
     MovementSpeed: 0.3
-
+    MaxCombatDistance: 25
   Equipment:
     - DIAMOND_BOOTS{enchants=DEPTH_STRIDER:3} FEET
   Drops:
@@ -42,6 +42,9 @@ OrbPiercer:
     - sound{s=mineinabyss:entity.orbpiercer.ambient;v=1;sc=HOSTILE} @self ~onTimer:400
     - skill{s=orbyATTACK} @self ~onAttack
     - skill{s=Changetarget} ~onTimer:160 <99%
+
+
+    - skill{s=orby_swim} @self ~onTimer:20
 
     - state{mid=orbpiercer;s=attack;li=3;lo=3} @self ~onAttack
     - skill{s=orbyspear} @target ~onTimer:20

--- a/servers/mobs/sync/plugins/MythicMobs/Mobs/mineinabyss/stingerhead.yml
+++ b/servers/mobs/sync/plugins/MythicMobs/Mobs/mineinabyss/stingerhead.yml
@@ -1,7 +1,7 @@
 Stingerhead:
   Type: SPIDER
   Display: 'StingerHead'
-  Health: 150
+  Health: 250
   Damage: 9
   AIGoalSelectors:
     - clear
@@ -19,8 +19,9 @@ Stingerhead:
     Collidable: true
     Silent: true
     FollowRange: 48
-    # MovementSpeed: 0.5
-    MaxCombatDistance: 30
+    MaxCombatDistance: 20
+    MovementSpeed: 0.25
+    MaxCombatDistance: 25
   Drops:
     - exp 400-500
     - geary mineinabyss:stingerhead_scale 1 0.25
@@ -50,8 +51,8 @@ Stingerhead:
     #- state{mid=stingerhead;s=spin_attack} @self ~onTimer:20
     #- skill{s=stingerhead_leap_attack} @self ~onTimer:20
 
-    - skill{s=stingerhead_stun50} @self ~onDamaged <50%
-    - skill{s=stingerhead_stun25} @self ~onDamaged <25% 0.1
+    #- skill{s=stingerhead_stun50} @self ~onDamaged <50%
+    #- skill{s=stingerhead_stun25} @self ~onDamaged <25% 0.1
     - skill{s=stingerhead_stun_hit} @self ~onDamaged
 
     # Bind a new MM entity to each stinger
@@ -109,7 +110,7 @@ Stingerhead_Stinger7:
 
 Stingerhead_Stinger_Template:
   Type: VEX
-  Health: 40
+  Health: 27
   Options:
     PreventOtherDrops: true
     Silent: true

--- a/servers/mobs/sync/plugins/MythicMobs/Skills/mineinabyss/kagi_tachikiri.yml
+++ b/servers/mobs/sync/plugins/MythicMobs/Skills/mineinabyss/kagi_tachikiri.yml
@@ -23,4 +23,4 @@ kagi_venom_impact:
     - effect:particles{particle=falling_obsidian_tear;amount=2;hS=.25;vS=.5;y=.5;repeat=30;repeatInterval=2}
     - potion{type=POISON;duration=20;level=2}
     - potion{type=BLINDNESS;duration=15;level=1}
-    - damage{a=8} @target
+    - damage{a=7} @target

--- a/servers/mobs/sync/plugins/MythicMobs/Skills/mineinabyss/orbpiercer.yml
+++ b/servers/mobs/sync/plugins/MythicMobs/Skills/mineinabyss/orbpiercer.yml
@@ -39,7 +39,13 @@ orbyATTACKDamage:
     #- skill{s=Bleeding} @target
     - throw{velocity=4;velocityY=2} @target
 
-
+orbyswim:
+  Conditions:
+  - inblock{b=WATER} true
+  Skills:
+  - look{headOnly=false;immediately=true;repeat=10;repeatInterval=2} @Target
+  - delay 10
+  - lunge{velocity=0.6;velocityY=0} @forward
 
 
 
@@ -247,23 +253,24 @@ orby_impale:
     - state{s=dash_charge;li=0;lo=0} @self
     - look{headOnly=false;immediately=false;repeat=100;repeatinterval=1} @target
     - delay 15
-    - leap{velocity=400} @Target
+    - leap{velocity=350} @Target
     - state{s=dash_charge;r=true} @self
     - state{s=dash_land_and_impale;li=0;lo=0} @self
-    - delay 8
+    - delay 3
     - look{headOnly=false;immediately=false;repeat=100;repeatinterval=1} @target
-    - totem{md=2;c=1;oH=orby_leapa;hnp=true;hp=true;hR=2;vR=2;i=1;repeat=20;repeatinterval=1} @forward{f=3}
+    - totem{md=2;c=1;oH=orby_leapa;hnp=true;hp=true;hR=2;vR=2;i=1;repeat=20;repeatinterval=1} @forward{f=5}
     - delay 34
     - state{s=dash_land_and_impale;remove=true} @self
     - setai{ai=true}
 orby_leapa:
   Cooldown: 3
   Conditions:
-    - targetwithin 3
+    - targetwithin 5
   Skills:
+    - shieldbreak{duration=300} @target
     - sound{s=item.trident.thunder} @PIR{r=30}
-    - stun{d=60;f=true} @PIR{r=3}
-    - damage{a=7} @PIR{r=3}
+    - stun{d=60;f=true} @PIR{r=4}
+    - damage{a=7} @PIR{r=4}
     - potion{type=POISON;duration=100;level=5} @PIR{r=3}
     - potion{type=WITHER;duration=30;level=1} @PIR{r=3}
     #- potion{t=SLOWNESS;d=100;l=2} @PIR{r=3}

--- a/servers/mobs/sync/plugins/MythicMobs/Skills/mineinabyss/silkfang.yml
+++ b/servers/mobs/sync/plugins/MythicMobs/Skills/mineinabyss/silkfang.yml
@@ -12,4 +12,3 @@ sfSpiderWebShot-Hit:
   - damage{a=2;pk=true} @target
   - potion{type=POISON;lvl=1;duration=100} @target 0.4
   - potion{type=HUNGER;lvl=1;duration=100} @target 0.4
-  - ignite{ticks=100} @target

--- a/servers/mobs/sync/plugins/MythicMobs/Skills/mineinabyss/splitjaw.yml
+++ b/servers/mobs/sync/plugins/MythicMobs/Skills/mineinabyss/splitjaw.yml
@@ -37,7 +37,7 @@ SJ_dash:
     - state{s=dash_charge;li=0;lo=0} @self
     - look{headOnly=false;immediately=false;repeat=100;repeatinterval=1} @target
     - delay 35
-    - leap{velocity=200} @Target
+    - leap{velocity=500} @Target
     - state{s=dash_charge;r=true} @self
     - state{s=dash_state;li=0;lo=0} @self
     - delay 4
@@ -51,9 +51,10 @@ SJ_dash:
 SJ_dashhit:
   Cooldown: 3
   Conditions:
-    - targetwithin5
+    - targetwithin 5
   Skills:
     - setstance{stance=dashhit} @self
+    - shieldbreak{duration=200} @target
     - damage{a=10} @PIR{r=3}
 
     - delay 100

--- a/servers/mobs/sync/plugins/MythicMobs/Skills/mineinabyss/stingerhead.yml
+++ b/servers/mobs/sync/plugins/MythicMobs/Skills/mineinabyss/stingerhead.yml
@@ -116,6 +116,7 @@ stingerhead_leapa:
     - gcd{ticks=20}
     - effect:sound{s=entity.fox.bite;v=1;p=1;} @target
     - damage{a=7} @target
+    - shieldbreak{duration=300} @target
     - skill{s=Bleeding} @target
     - skill{s=stingerhead_venom_impact} @target
     - potion{t=SLOW;d=20;l=7}
@@ -127,17 +128,21 @@ stingerhead_stun50:
     - setvariable{var=target.stun25;value=1;save=true} @self
     - setAI{ai=false} @self
     - state{m=stingerhead;s=stun} @self
+    - setstance{stance=stun} @self
     - delay 30
     - setstance{stance=stun} @self
     - setai{ai=true} @self
+    - setstance{stance=nostun} @self
 stingerhead_stun25:
   Conditions:
-    - variableisset{var=target.stun25} false
+   # - variableisset{var=target.stun25} false
   Skills:
-    - setvariable{var=target.stun25;value=1;save=true} @self
+    #- setvariable{var=target.stun25;value=1;save=true} @self
     - setAI{ai=false} @self
-    - state{s=stun} @self
-    - setstance{s=stun} @self
+    - state{m=stingerhead;s=stun} @self
+    - setstance{stance=stun} @self
+    - delay 50
+    - setstance{stance=nostun} @self
     - setai{ai=true} @self
 stingerhead_stun_end:
   Skills:
@@ -148,7 +153,7 @@ stingerhead_stun_hit:
   Conditions:
     - stance stun
   Skills:
-  #- state{m=stingerhead;s=stun_hit} @self
+    - state{m=stingerhead;s=stun_hit} @self
 
 ## Stingerhead Stinger skills
 stingerhead_stinger_detached_spawn:
@@ -172,6 +177,7 @@ stingerhead_detach_stinger:
   Skills:
     - variablesubtract{var=target.stingerhead_stinger_count;amount=1}
     - submodel{mid=stingerhead;subpart=stinger<skill.stinger_part>_secondary;remove=true} @parent
+    - skill{s=stingerhead_stun25} @self
     - summon{t=Stingerhead_Stinger_Detached} @self
     - throw{v=7;vy=2;delay=1} @MobsInRadius{r=5;types=Stingerhead_Stinger_Detached}
 
@@ -222,7 +228,7 @@ stingerhead_venom_stinger:
   - potion{type=POISON;duration=<caster.stingerhead_stinger_count>*1.5;level=<caster.stingerhead_stinger_count>-1} @trigger
 
 stingerhead_spin:
-  Cooldown: 8
+  Cooldown: 4
   Conditions:
     - offgcd
   TargetConditions:
@@ -235,6 +241,7 @@ stingerhead_spin:
       - sound{s=item.trident.riptide_3;p=0.65;v=0.5} @self
       - sound{s=entity.player.attack.sweep;p=0.65;v=0.5} @self
       - damage{amount=10} @PIR{r=5}
+      - shieldbreak{duration=200} @target
       - throw{v=10;vy=4} @PIR{r=5}
       ]} @EIR{r=5;ignore=faction}
     - delay 20
@@ -249,4 +256,4 @@ Bleeding:
   Skills:
     - effect:sound{s=entity.generic.hurt;v=1;p=1;} @target
     - effect:particles{p=dripLava;vs=0.5;hs=0.5;a=10;s=0.25;y=0.5;repeat=5;repeatInterval=20} @target
-    - damage{a=2;repeat=5;repeatInterval=20;pkb=false} @target
+    - damage{a=3;repeat=5;repeatInterval=20;pkb=false} @target


### PR DESCRIPTION
Made big mobs apply shield break.

Reworked stingerhead to only be stunned upon stinger break and increased hp and reduced movement speed.
nerfed kagi (movement speed,damage,poison)
taught orby to swim
nerfed stinger hp from 40-27 to make easier to stun
gave stingerhead/orby maxcombatdistance 25 so you cannot damage them outside of 25 blocks range
messed with leap hitboxes to make it hit more
increased splitjaw range on leap