### PR TITLE
baby kuon nerf just dropped (and onitsuchi fix)

### DIFF
--- a/servers/mobs/sync/plugins/Geary/mineinabyss/mobs/hostile/kuongatari.yml
+++ b/servers/mobs/sync/plugins/Geary/mineinabyss/mobs/hostile/kuongatari.yml
@@ -1,14 +1,15 @@
 namespaces: [geary, mobzy, looty]
 set.mythicMob: Kuongatari
 displayName: "<#1FB53D>Kuongatari"
-drop:
-  - exp: 10..25
-  - item: mineinabyss:kuongatari_juice
-    amount: 1..2
-    dropChance: 0.6
-  - item: mineinabyss:kuongatari_silk
-    amount: 1..3
-    dropChance: 0.65
-  - item: mineinabyss:kuongatari_abdomen_raw
-    cooked: mineinabyss:kuongatari_abdomen_cooked
-    dropChance: 0.75
+deathLoot:
+  exp: 10..25
+  drops:
+    - item: { prefab: mineinabyss:kuongatari_juice }
+      amount: 1..2
+      dropChance: 0.6
+    - item: { prefab: mineinabyss:kuongatari_silk }
+      amount: 1..3
+      dropChance: 0.65
+    - item: { prefab: mineinabyss:kuongatari_abdomen_raw }
+      cooked: { prefab: mineinabyss:kuongatari_abdomen_cooked }
+      dropChance: 0.75

--- a/servers/mobs/sync/plugins/Geary/mineinabyss/mobs/hostile/kuongatari.yml
+++ b/servers/mobs/sync/plugins/Geary/mineinabyss/mobs/hostile/kuongatari.yml
@@ -1,3 +1,14 @@
 namespaces: [geary, mobzy, looty]
 set.mythicMob: Kuongatari
 displayName: "<#1FB53D>Kuongatari"
+drop:
+  - exp: 10..25
+  - item: mineinabyss:kuongatari_juice
+    amount: 1..2
+    dropChance: 0.6
+  - item: mineinabyss:kuongatari_silk
+    amount: 1..3
+    dropChance: 0.65
+  - item: mineinabyss:kuongatari_abdomen_raw
+    cooked: mineinabyss:kuongatari_abdomen_cooked
+    dropChance: 0.75

--- a/servers/mobs/sync/plugins/Geary/mineinabyss/mobs/spawns/general/spawn.kuongatari.yml
+++ b/servers/mobs/sync/plugins/Geary/mineinabyss/mobs/spawns/general/spawn.kuongatari.yml
@@ -2,9 +2,9 @@ namespaces: [geary, mobzy, looty]
 spawn.type:
   prefab: mineinabyss:kuongatari
 spawn.amount:
-  amount: 2..5
+  amount: 1..3
 spawn.spread:
-  radius: 10
+  radius: 4
 spawn.priority:
   priority: 0.6
 check.spawn.local_group:
@@ -13,7 +13,7 @@ check.spawn.local_group:
 check.spawn.gap:
   range: 3..4096
 check.spawn.delay:
-  attemptEvery: 4s
+  attemptEvery: 5s
 check.blockType:
   allow:
     - GRASS_BLOCK

--- a/servers/mobs/sync/plugins/MythicMobs/Mobs/mineinabyss/flying/onitsuchi.yml
+++ b/servers/mobs/sync/plugins/MythicMobs/Mobs/mineinabyss/flying/onitsuchi.yml
@@ -1,7 +1,7 @@
 onitsuchi:
   Type: ALLAY
-  Health: 30
-  Damage: 5
+  Health: 40
+  Damage: 7
   AIGoalSelectors:
     - clear
     - meleeattack{speed=1.5;range=1.5}
@@ -27,7 +27,7 @@ onitsuchi:
     DamageTint: true
   Skills:
 
-    - CancelEvent{sync=true} ~onAttack
+    #- CancelEvent{sync=true} ~onAttack
 
     - bodyclamp{m=onitsuchi;c=15} @self ~onSpawn
     - bodyclamp{m=onitsuchi;c=15} @self ~onLoad

--- a/servers/mobs/sync/plugins/MythicMobs/Mobs/mineinabyss/kuongatari.yml
+++ b/servers/mobs/sync/plugins/MythicMobs/Mobs/mineinabyss/kuongatari.yml
@@ -1,6 +1,6 @@
 Kuongatari:
   Type: CAVE_SPIDER
-  Health: 43
+  Health: 50
   Damage: 8
   AITargetSelectors:
     - clear
@@ -8,14 +8,13 @@ Kuongatari:
     - players
   Options:
     PreventSunBurn: true
-    PreventOtherDrops: true
     KnockbackResistance: 1
     #DigOutOfGround: true
     Collidable: true
     #Silent: false
     FollowRange: 20
     MovementSpeed: 0.32
-    MaxCombatDistance: 35
+    MaxCombatDistance: 20
     DigOutOfGround: true
   Model:
     Id: kuongatari
@@ -25,17 +24,17 @@ Kuongatari:
     Scale: 1.2
   DamageModifiers:
     - DROWNING 0
-    - FIRE 5
-    - FIRE_TICK 2
+    - FIRE 15
+    - FIRE_TICK 3
   Skills:
-    - skill{s=Kuon_Summon} @target ~onDamaged <40% 0.2
-    - shieldbreak{duration=100} @target ~onattack 0.35
+    - skill{s=Kuon_Summon} @target ~onDamaged <40% 0.1
+    - shieldbreak{duration=100} @target ~onattack 0.5
     - dismount ~onTimer:20
 Kuongatari_summon:
-  Type: CAVE_SPIDER
-  Display: Kuongatari_Summon
-  Health: 20
-  Damage: 7
+  Type: SPIDER
+  Display: "Baby Kuongatari"
+  Health: 16
+  Damage: 6
   AITargetSelectors:
     - clear
     - attacker
@@ -47,25 +46,25 @@ Kuongatari_summon:
     #DigOutOfGround: true
     Collidable: true
    # Silent: true
-    FollowRange: 48
+    FollowRange: 30
     MovementSpeed: 0.4
-    MaxCombatDistance: 35
+    MaxCombatDistance: 20
   Equipment:
     - TORCH HAND
   Drops:
     - exp 5-15
-    - geary mineinabyss:kuongatari_juice 1 0.025
-    - geary mineinabyss:kuongatari_silk 1 0.1
+    - geary mineinabyss:kuongatari_juice 1 0.04
+    - geary mineinabyss:kuongatari_silk 1-2 0.2
   Model:
     Id: kuongatari
     ViewRadius: 64
     Drive: false
     DamageTint: true
-    Scale: 0.5
+    Scale: 0.7
   DamageModifiers:
     - DROWNING 0
-    - FIRE 5
-    - FIRE_TICK 2
+    - FIRE 15
+    - FIRE_TICK 3
   Skills:
     - dismount ~onTimer:20
     - shieldbreak{duration=100} @target ~onattack 0.35

--- a/servers/mobs/sync/plugins/MythicMobs/Skills/mineinabyss/Kuongatari.yml
+++ b/servers/mobs/sync/plugins/MythicMobs/Skills/mineinabyss/Kuongatari.yml
@@ -6,4 +6,4 @@ Kuon_Summon:
     - incombat true
   Skills:
     - gcd{ticks=99999}
-    - summon{type=Kuongatari_summon;amount=4;radius=4} @self
+    - summon{type=Kuongatari_summon;amount=4;radius=3} @self


### PR DESCRIPTION
fixed kuon not having drops
increased kuon fire damage taken from 5x-15x
made baby kuon summon ability rarer
doubled baby kuon drop rate
fixed kuongatari_summon into baby kuongatari
fixed onitsuchi not doing damage and increased its base health (its a layer 5 mob afterall)
made kuons span 1-3 instead of 2-5 (increased drops to make up for it)