### PR TITLE
Fix: Relicbow drop displaying wrong Grade

### DIFF
--- a/plugins/Geary/prefabs/mineinabyss/items/event/april_fools/amongus_cosmetic_new.yml
+++ b/plugins/Geary/prefabs/mineinabyss/items/event/april_fools/amongus_cosmetic_new.yml
@@ -9,24 +9,24 @@ set.item:
   - <gold>RIGHT CLICK TO OBTAIN WARDROBE COSMETIC
   - <gold>THIS WILL CONSUME YOUR ITEM
   enchantable: 0
-observe:
-  itemRightClick:
-  - become: parent
-  - ensure:
-      mythicConditions:
-      - haspermission{p=hmccosmetics.hat.amongus_cosmetic} false
-    onFail:
-    - sendActionBar:
-        text: <#454A46>You already have this cosmetic
-  - cooldown:
-      id: cosmetic
-      length: 10s
-      display: <#454A46>You already have this cosmetic
-  - mythicSkills:
-    - hmc_amongus_cosmetic
-  - consumeItem:
-      type: mineinabyss:amongus_cosmetic_new
-    when:
-    - chance: 1
+# observe:
+#   itemRightClick:
+#   - become: parent
+#   - ensure:
+#       mythicConditions:
+#       - haspermission{p=hmccosmetics.hat.amongus_cosmetic} false
+#     onFail:
+#     - sendActionBar:
+#         text: <#454A46>You already have this cosmetic
+#   - cooldown:
+#       id: cosmetic
+#       length: 10s
+#       display: <#454A46>You already have this cosmetic
+#   - mythicSkills:
+#     - hmc_amongus_cosmetic
+#   - consumeItem:
+#       type: mineinabyss:amongus_cosmetic_new
+#     when:
+#     - chance: 1
 resourcepack:
   model: mineinabyss:item/event/red_imposter_hat

--- a/plugins/Geary/prefabs/mineinabyss/items/event/april_fools/clown_mask_new.yml
+++ b/plugins/Geary/prefabs/mineinabyss/items/event/april_fools/clown_mask_new.yml
@@ -10,24 +10,24 @@ set.item:
   - <gold>THIS WILL CONSUME YOUR ITEM
   enchantable: 0
 disableItemInteractions: {}
-observe:
-  itemRightClick:
-  - become: parent
-  - ensure:
-      mythicConditions:
-      - haspermission{p=hmccosmetics.hat.clown_mask} false
-    onFail:
-    - sendActionBar:
-        text: <#454A46>You already have this cosmetic
-  - cooldown:
-      id: cosmetic
-      length: 10s
-      display: <#454A46>You already have this cosmetic
-  - mythicSkills:
-    - hmc_clown_mask_cosmetic
-  - consumeItem:
-      type: mineinabyss:clown_mask_new
-    when:
-    - chance: 1
+# observe:
+#   itemRightClick:
+#   - become: parent
+#   - ensure:
+#       mythicConditions:
+#       - haspermission{p=hmccosmetics.hat.clown_mask} false
+#     onFail:
+#     - sendActionBar:
+#         text: <#454A46>You already have this cosmetic
+#   - cooldown:
+#       id: cosmetic
+#       length: 10s
+#       display: <#454A46>You already have this cosmetic
+#   - mythicSkills:
+#     - hmc_clown_mask_cosmetic
+#   - consumeItem:
+#       type: mineinabyss:clown_mask_new
+#     when:
+#     - chance: 1
 resourcepack:
   model: mineinabyss:item/event/clown_mask

--- a/plugins/Geary/prefabs/mineinabyss/items/event/april_fools/tama_hat.yml
+++ b/plugins/Geary/prefabs/mineinabyss/items/event/april_fools/tama_hat.yml
@@ -10,24 +10,24 @@ set.item:
   - <gold>THIS WILL CONSUME YOUR ITEM
   enchantable: 0
 disableItemInteractions: {}
-observe:
-  itemRightClick:
-  - become: parent
-  - ensure:
-      mythicConditions:
-      - haspermission{p=hmccosmetics.hat.tama_hat} false
-    onFail:
-    - sendActionBar:
-        text: <#454A46>You already have this cosmetic
-  - cooldown:
-      id: cosmetic
-      length: 10s
-      display: <#454A46>You already have this cosmetic
-  - mythicSkills:
-    - hmc_tama_hat
-  - consumeItem:
-      type: mineinabyss:tama_hat
-    when:
-    - chance: 1
+# observe:
+#   itemRightClick:
+#   - become: parent
+#   - ensure:
+#       mythicConditions:
+#       - haspermission{p=hmccosmetics.hat.tama_hat} false
+#     onFail:
+#     - sendActionBar:
+#         text: <#454A46>You already have this cosmetic
+#   - cooldown:
+#       id: cosmetic
+#       length: 10s
+#       display: <#454A46>You already have this cosmetic
+#   - mythicSkills:
+#     - hmc_tama_hat
+#   - consumeItem:
+#       type: mineinabyss:tama_hat
+#     when:
+#     - chance: 1
 resourcepack:
   model: mineinabyss:item/event/tama_hat

--- a/plugins/MythicMobs/mobs/mineinabyss/prayingskeletons/prayingSkeleton_l2.yml
+++ b/plugins/MythicMobs/mobs/mineinabyss/prayingskeletons/prayingSkeleton_l2.yml
@@ -16,4 +16,4 @@ prayingSkeleton_l2:
     - skill{s=relicDrop;delay=10;item=VineCharmDrop;grade=2} ~onDeath 0.01
     - skill{s=relicDrop;delay=15;item=VerdauEffaxDrop;grade=3} ~onDeath 0.025
     - skill{s=relicDrop;delay=20;item=AnimalTotemDrop;grade=4} ~onDeath 0.05
-    - skill{s=relicDrop;item=RelicBowDrop;grade=4} ~onDeath 0.002
+    - skill{s=relicDrop;item=RelicBowDrop;grade=1} ~onDeath 0.002


### PR DESCRIPTION
- fixed praying skeleton drop message for the relicbow
- commented out permission skills on april fool event cosmetics to avoid item removal mishaps (waiting for us to figure out how to "fix" the issue.